### PR TITLE
fix: _acceptFundsFor returns balance delta instead of total balance

### DIFF
--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -832,11 +832,14 @@ contract JBSwapTerminal is
                 catch {}
         }
 
+        // Get a reference to the balance before receiving tokens.
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+
         // Transfer the tokens from the `msg.sender` to this terminal.
         _transferFrom({from: msg.sender, to: payable(address(this)), token: token, amount: amount});
 
-        // The amount actually received.
-        return IERC20(token).balanceOf(address(this));
+        // The amount should reflect the change in balance.
+        return IERC20(token).balanceOf(address(this)) - balanceBefore;
     }
 
     /// @notice Logic to be triggered before transferring tokens from this terminal.

--- a/src/JBSwapTerminal5_1.sol
+++ b/src/JBSwapTerminal5_1.sol
@@ -832,11 +832,14 @@ contract JBSwapTerminal5_1 is
                 catch {}
         }
 
+        // Get a reference to the balance before receiving tokens.
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+
         // Transfer the tokens from the `msg.sender` to this terminal.
         _transferFrom({from: msg.sender, to: payable(address(this)), token: token, amount: amount});
 
-        // The amount actually received.
-        return IERC20(token).balanceOf(address(this));
+        // The amount should reflect the change in balance.
+        return IERC20(token).balanceOf(address(this)) - balanceBefore;
     }
 
     /// @notice Logic to be triggered before transferring tokens from this terminal.


### PR DESCRIPTION
Previously returned IERC20(token).balanceOf(address(this)) which includes any pre-existing balance (dust, failed ops). Now captures balanceBefore and returns the actual delta, matching JBMultiTerminal's implementation.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: