### PR TITLE
fix: return amount directly from _acceptFundsFor instead of balanceOf

### DIFF
--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -830,8 +830,8 @@ contract JBSwapTerminal is
         // Transfer the tokens from the `msg.sender` to this terminal.
         _transferFrom({from: msg.sender, to: payable(address(this)), token: token, amount: amount});
 
-        // The amount actually received.
-        return IERC20(token).balanceOf(address(this));
+        // Return the amount transferred. Fee-on-transfer tokens are not supported by the swap terminal.
+        return amount;
     }
 
     /// @notice Logic to be triggered before transferring tokens from this terminal.

--- a/src/JBSwapTerminal5_1.sol
+++ b/src/JBSwapTerminal5_1.sol
@@ -835,8 +835,8 @@ contract JBSwapTerminal5_1 is
         // Transfer the tokens from the `msg.sender` to this terminal.
         _transferFrom({from: msg.sender, to: payable(address(this)), token: token, amount: amount});
 
-        // The amount actually received.
-        return IERC20(token).balanceOf(address(this));
+        // Return the amount transferred. Fee-on-transfer tokens are not supported by the swap terminal.
+        return amount;
     }
 
     /// @notice Logic to be triggered before transferring tokens from this terminal.

--- a/src/JBSwapTerminalRegistry.sol
+++ b/src/JBSwapTerminalRegistry.sol
@@ -438,8 +438,8 @@ contract JBSwapTerminalRegistry is IJBSwapTerminalRegistry, JBPermissioned, Owna
         // Transfer the tokens from the `_msgSender()` to this terminal.
         _transferFrom({from: _msgSender(), to: payable(address(this)), token: token, amount: amount});
 
-        // The amount actually received.
-        return IERC20(token).balanceOf(address(this));
+        // Return the amount transferred. Fee-on-transfer tokens are not supported by the swap terminal.
+        return amount;
     }
 
     /// @notice Logic to be triggered before transferring tokens from this terminal.

--- a/test/Units/AddToBalanceOf.t.sol
+++ b/test/Units/AddToBalanceOf.t.sol
@@ -322,7 +322,7 @@ contract JBSwapTerminaladdToBalanceOf is UnitFixture {
         // no allowance granted outside of permit2
         mockExpectCall(tokenIn, abi.encodeCall(IERC20.allowance, (caller, address(swapTerminal))), abi.encode(0));
 
-        mockExpectCall(tokenIn, abi.encodeCall(IERC20.balanceOf, (address(swapTerminal))), abi.encode(amountIn));
+        vm.mockCall(tokenIn, abi.encodeCall(IERC20.balanceOf, (address(swapTerminal))), abi.encode(amountIn));
 
         // Mock the swap - this is where we make most of the tests
         mockExpectCall(

--- a/test/Units/Pay.t.sol
+++ b/test/Units/Pay.t.sol
@@ -162,7 +162,7 @@ contract JBSwapTerminalpay is UnitFixture {
             allowances
         );
 
-        mockExpectCall(tokenIn, abi.encodeCall(IERC20.balanceOf, address(swapTerminal)), abi.encode(amountIn));
+        vm.mockCall(tokenIn, abi.encodeCall(IERC20.balanceOf, address(swapTerminal)), abi.encode(amountIn));
 
         bytes memory quoteMetadata = _createMetadata(
             JBMetadataResolver.getId("quoteForSwap", address(swapTerminal)), abi.encode(amountOut, pool)
@@ -347,7 +347,7 @@ contract JBSwapTerminalpay is UnitFixture {
         // no allowance granted outside of permit2
         mockExpectCall(tokenIn, abi.encodeCall(IERC20.allowance, (caller, address(swapTerminal))), abi.encode(0));
 
-        mockExpectCall(tokenIn, abi.encodeCall(IERC20.balanceOf, (address(swapTerminal))), abi.encode(amountIn));
+        vm.mockCall(tokenIn, abi.encodeCall(IERC20.balanceOf, (address(swapTerminal))), abi.encode(amountIn));
 
         // Mock the swap - this is where we make most of the tests
         mockExpectCall(
@@ -469,9 +469,9 @@ contract JBSwapTerminalpay is UnitFixture {
             allowances
         );
 
-        mockExpectCall(tokenIn, abi.encodeCall(IERC20.balanceOf, (address(swapTerminalRegistry))), abi.encode(amountIn));
+        vm.mockCall(tokenIn, abi.encodeCall(IERC20.balanceOf, (address(swapTerminalRegistry))), abi.encode(amountIn));
 
-        mockExpectCall(tokenIn, abi.encodeCall(IERC20.balanceOf, (address(swapTerminal))), abi.encode(amountIn));
+        vm.mockCall(tokenIn, abi.encodeCall(IERC20.balanceOf, (address(swapTerminal))), abi.encode(amountIn));
 
         // Mock the swap - this is where we make most of the tests
         mockExpectCall(

--- a/test/helper/UnitFixture.sol
+++ b/test/helper/UnitFixture.sol
@@ -85,7 +85,8 @@ contract UnitFixture is Test {
 
         mockExpectCall(token, abi.encodeCall(IERC20.transferFrom, (from, to, amount)), abi.encode(true));
 
-        mockExpectCall(token, abi.encodeCall(IERC20.balanceOf, to), abi.encode(amount));
+        // Mock balanceOf for the leftover check (no expectation — _acceptFundsFor no longer calls balanceOf)
+        vm.mockCall(token, abi.encodeCall(IERC20.balanceOf, to), abi.encode(amount));
     }
 
     // compare 2 uniswap v3 pool addresses


### PR DESCRIPTION
Fee-on-transfer tokens are not supported by the swap terminal, so returning the transfer amount directly is equivalent and avoids an unnecessary external call. Tests updated to remove balanceOf expectations from _acceptFundsFor while preserving the leftover check mocks.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: