### PR TITLE
L-33: Disable increaseObservationCardinalityNext in addDefaultPool

### DIFF
--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -576,7 +576,8 @@ contract JBSwapTerminal is
         }
 
         // Call the pool to increase the cardinality, if the cardinality is already higher this is a no-op.
-        pool.increaseObservationCardinalityNext(MIN_DEFAULT_POOL_CARDINALITY);
+        // slither-disable-next-line reentrancy-benign
+        // pool.increaseObservationCardinalityNext(MIN_DEFAULT_POOL_CARDINALITY);
 
         // Store the token as having an accounting context.
         if (_poolFor[projectId][normalizedTokenIn] == IUniswapV3Pool(address(0))) {


### PR DESCRIPTION
## Summary
- Disables the `pool.increaseObservationCardinalityNext(MIN_DEFAULT_POOL_CARDINALITY)` call in `addDefaultPool`
- This external call is unnecessary now that M-3/M-23 handles insufficient TWAP observations by reverting
- Removes an external call surface during pool configuration

## Audit Finding
**L-33**: The `increaseObservationCardinalityNext` call is redundant overhead — it doesn't guarantee the TWAP window will be satisfied, and the M-3/M-23 revert-on-insufficient-observations approach is the correct safety mechanism.

## Test plan
- [ ] Verify existing tests pass without the cardinality call
- [ ] Confirm M-3/M-23 revert still protects against insufficient observations

🤖 Generated with [Claude Code](https://claude.com/claude-code)