### PR TITLE
fix: align interface arg names with implementation

### DIFF
--- a/script/ConfigurePairs.s.sol
+++ b/script/ConfigurePairs.s.sol
@@ -169,6 +169,6 @@ contract ConfigurePairs is Script, Sphinx {
 
         // Add the pair to the swap terminal.
         swapTerminal.swap_terminal.addDefaultPool({projectId: projectId, token: token, pool: pool});
-        swapTerminal.swap_terminal.addTwapParamsFor({projectId: projectId, pool: pool, secondsAgo: twapWindow});
+        swapTerminal.swap_terminal.addTwapParamsFor({projectId: projectId, pool: pool, twapWindow: twapWindow});
     }
 }

--- a/script/DeployUSDC.s.sol
+++ b/script/DeployUSDC.s.sol
@@ -258,6 +258,6 @@ contract DeployUSDCScript is Script, Sphinx {
 
         // Add the pair to the swap terminal.
         swapTerminal.addDefaultPool({projectId: 0, token: token, pool: pool});
-        swapTerminal.addTwapParamsFor({projectId: 0, pool: pool, secondsAgo: twapWindow});
+        swapTerminal.addTwapParamsFor({projectId: 0, pool: pool, twapWindow: twapWindow});
     }
 }

--- a/src/interfaces/IJBSwapTerminal.sol
+++ b/src/interfaces/IJBSwapTerminal.sol
@@ -14,5 +14,5 @@ interface IJBSwapTerminal {
     function twapWindowOf(uint256 projectId, IUniswapV3Pool pool) external view returns (uint256);
 
     function addDefaultPool(uint256 projectId, address token, IUniswapV3Pool pool) external;
-    function addTwapParamsFor(uint256 projectId, IUniswapV3Pool pool, uint256 secondsAgo) external;
+    function addTwapParamsFor(uint256 projectId, IUniswapV3Pool pool, uint256 twapWindow) external;
 }


### PR DESCRIPTION
## Summary
- Renames `secondsAgo` to `twapWindow` in `IJBSwapTerminal.addTwapParamsFor` to match the implementation
- Updates deploy scripts (`DeployUSDC.s.sol`, `ConfigurePairs.s.sol`) to use the renamed parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)