### PR TITLE
Append V6 to deploy salts

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -26,7 +26,7 @@ contract DeployScript is Script, Sphinx {
     IPermit2 permit2;
 
     /// @notice the salts that are used to deploy the contracts.
-    bytes32 SWAP_TERMINAL = "JBSwapTerminal";
+    bytes32 SWAP_TERMINAL = "JBSwapTerminalV6";
 
     function configureSphinx() public override {
         sphinxConfig.projectName = "nana-swap-terminal-v5";

--- a/script/DeployAndConfigure5_1.s.sol
+++ b/script/DeployAndConfigure5_1.s.sol
@@ -38,7 +38,7 @@ contract DeployScript is Script, Sphinx {
     uint256 constant ARBITRUM_SEPOLIA = 421_614;
 
     /// @notice the salts that are used to deploy the contracts.
-    bytes32 SWAP_TERMINAL = "JBSwapTerminal";
+    bytes32 SWAP_TERMINAL = "JBSwapTerminalV6";
 
     function configureSphinx() public override {
         sphinxConfig.projectName = "nana-swap-terminal-v5";

--- a/script/DeployUSDC.s.sol
+++ b/script/DeployUSDC.s.sol
@@ -42,7 +42,7 @@ contract DeployUSDCScript is Script, Sphinx {
     IJBSwapTerminal swapTerminal;
 
     /// @notice the salts that are used to deploy the contracts.
-    bytes32 SWAP_TERMINAL = "JBSwapTerminal_";
+    bytes32 SWAP_TERMINAL = "JBSwapTerminalV6_";
 
     function configureSphinx() public override {
         sphinxConfig.projectName = "nana-swap-terminal-v5";


### PR DESCRIPTION
## Summary
- Updated `SWAP_TERMINAL` salt with V6 suffix in `Deploy.s.sol`, `DeployUSDC.s.sol`, and `DeployAndConfigure5_1.s.sol`

Ensures all V6 contracts deploy to different deterministic addresses than V5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)