### PR TITLE
chore: v6 QC pass

### DIFF
--- a/src/JBSwapTerminal.sol
+++ b/src/JBSwapTerminal.sol
@@ -304,14 +304,16 @@ contract JBSwapTerminal is
     )
         external
         view
+        override
         returns (uint256)
     {}
 
     /// @notice Returns the default pool for a given project and token or, if a project has no default pool for the
-    ///         token, the overal default pool for the token
+    ///         token, the overall default pool for the token.
     /// @param projectId The ID of the project to retrieve the default pool for.
     /// @param tokenIn The address of the token to retrieve the default pool for.
-    /// @return pool The default pool for the token, or the overall default pool for the token if the
+    /// @return pool The default pool for the token, or the overall default pool for the token if the project has none.
+    /// @return zeroForOne Whether `tokenIn` is token0 in the pool (true) or token1 (false).
     function getPoolFor(
         uint256 projectId,
         address tokenIn

--- a/src/JBSwapTerminalRegistry.sol
+++ b/src/JBSwapTerminalRegistry.sol
@@ -46,21 +46,21 @@ contract JBSwapTerminalRegistry is IJBSwapTerminalRegistry, JBPermissioned, Owna
     IJBProjects public immutable override PROJECTS;
 
     /// @notice The permit2 utility.
-    IPermit2 public immutable PERMIT2;
+    IPermit2 public immutable override PERMIT2;
 
     //*********************************************************************//
     // --------------------- public stored properties -------------------- //
     //*********************************************************************//
 
-    /// @notice The default hook to use.
+    /// @notice The default terminal to use.
     IJBTerminal public override defaultTerminal;
 
     /// @notice Whether the terminal for the given project is locked.
-    /// @custom:param projectId The ID of the project to get the locked hook for.
+    /// @custom:param projectId The ID of the project to get the locked terminal for.
     mapping(uint256 projectId => bool) public override hasLockedTerminal;
 
-    /// @notice The address of each project's token.
-    /// @custom:param projectId The ID of the project the token belongs to.
+    /// @notice Whether the given terminal is allowed to be set for projects.
+    /// @custom:param terminal The terminal to check.
     mapping(IJBTerminal terminal => bool) public override isTerminalAllowed;
 
     //*********************************************************************//
@@ -157,6 +157,7 @@ contract JBSwapTerminalRegistry is IJBSwapTerminalRegistry, JBPermissioned, Owna
     )
         external
         view
+        override
         returns (uint256)
     {}
 
@@ -248,8 +249,8 @@ contract JBSwapTerminalRegistry is IJBSwapTerminalRegistry, JBPermissioned, Owna
         });
     }
 
-    /// @notice Allow a hook.
-    /// @dev Only the owner can allow a hook.
+    /// @notice Allow a terminal.
+    /// @dev Only the owner can allow a terminal.
     /// @param terminal The terminal to allow.
     function allowTerminal(IJBTerminal terminal) external onlyOwner {
         // Allow the terminal.
@@ -259,10 +260,10 @@ contract JBSwapTerminalRegistry is IJBSwapTerminalRegistry, JBPermissioned, Owna
     }
 
     /// @notice Disallow a terminal.
-    /// @dev Only the owner can disallow a hook.
+    /// @dev Only the owner can disallow a terminal.
     /// @param terminal The terminal to disallow.
     function disallowTerminal(IJBTerminal terminal) external onlyOwner {
-        // Disallow the hook.
+        // Disallow the terminal.
         isTerminalAllowed[terminal] = false;
 
         // L-26: Clear default terminal if it matches the terminal being disallowed.
@@ -364,7 +365,7 @@ contract JBSwapTerminalRegistry is IJBSwapTerminalRegistry, JBPermissioned, Owna
     }
 
     /// @notice Set the default terminal.
-    /// @dev Only the owner can set the default hook.
+    /// @dev Only the owner can set the default terminal.
     /// @param terminal The terminal to set as the default.
     function setDefaultTerminal(IJBTerminal terminal) external onlyOwner {
         // Set the default terminal.
@@ -383,7 +384,7 @@ contract JBSwapTerminalRegistry is IJBSwapTerminalRegistry, JBPermissioned, Owna
     /// @param projectId The ID of the project to set the terminal for.
     /// @param terminal The terminal to set for the project.
     function setTerminalFor(uint256 projectId, IJBTerminal terminal) external {
-        // Make sure the hook is not locked.
+        // Make sure the terminal is not locked.
         if (hasLockedTerminal[projectId]) revert JBSwapTerminalRegistry_TerminalLocked(projectId);
 
         if (!isTerminalAllowed[terminal]) revert JBSwapTerminalRegistry_TerminalNotAllowed(terminal);

--- a/src/interfaces/IJBSwapTerminal.sol
+++ b/src/interfaces/IJBSwapTerminal.sol
@@ -4,15 +4,45 @@ pragma solidity ^0.8.0;
 import {IUniswapV3Pool} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 
 interface IJBSwapTerminal {
+    /// @notice The project ID used for storing default values (pool defaults, accounting contexts).
+    /// @return The default project ID (0).
     function DEFAULT_PROJECT_ID() external view returns (uint256);
+
+    /// @notice The maximum TWAP window that can be set for a project's pool.
+    /// @return The maximum TWAP window in seconds.
     function MAX_TWAP_WINDOW() external view returns (uint256);
+
+    /// @notice The minimum TWAP window that can be set for a project's pool.
+    /// @return The minimum TWAP window in seconds.
     function MIN_TWAP_WINDOW() external view returns (uint256);
+
+    /// @notice The minimum cardinality for a pool to be configured as a default pool.
+    /// @return The minimum cardinality.
     function MIN_DEFAULT_POOL_CARDINALITY() external view returns (uint16);
+
+    /// @notice The uncertain slippage tolerance allowed when the swap size relative to liquidity is ambiguous.
+    /// @return The uncertain slippage tolerance.
     function UNCERTAIN_SLIPPAGE_TOLERANCE() external view returns (uint256);
+
+    /// @notice The denominator used when calculating TWAP slippage tolerance values.
+    /// @return The slippage denominator.
     function SLIPPAGE_DENOMINATOR() external view returns (uint160);
 
+    /// @notice The TWAP window for a given project and pool.
+    /// @param projectId The ID of the project.
+    /// @param pool The Uniswap v3 pool.
+    /// @return The TWAP window in seconds.
     function twapWindowOf(uint256 projectId, IUniswapV3Pool pool) external view returns (uint256);
 
+    /// @notice Add a default pool for a given project and token, setting up the accounting context.
+    /// @param projectId The ID of the project to add the default pool for.
+    /// @param token The address of the token to add the default pool for.
+    /// @param pool The Uniswap v3 pool to set as the default.
     function addDefaultPool(uint256 projectId, address token, IUniswapV3Pool pool) external;
+
+    /// @notice Set or update the TWAP parameters for a given project and pool.
+    /// @param projectId The ID of the project to set the TWAP parameters for.
+    /// @param pool The Uniswap v3 pool to set the TWAP parameters for.
+    /// @param twapWindow The TWAP window in seconds.
     function addTwapParamsFor(uint256 projectId, IUniswapV3Pool pool, uint256 twapWindow) external;
 }

--- a/src/interfaces/IJBSwapTerminalRegistry.sol
+++ b/src/interfaces/IJBSwapTerminalRegistry.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import {IJBProjects} from "@bananapus/core-v6/src/interfaces/IJBProjects.sol";
 import {IJBTerminal} from "@bananapus/core-v6/src/interfaces/IJBTerminal.sol";
+import {IPermit2} from "@uniswap/permit2/src/interfaces/IPermit2.sol";
 
 interface IJBSwapTerminalRegistry is IJBTerminal {
     event JBSwapTerminalRegistry_AllowTerminal(IJBTerminal terminal);
@@ -11,16 +12,51 @@ interface IJBSwapTerminalRegistry is IJBTerminal {
     event JBSwapTerminalRegistry_SetDefaultTerminal(IJBTerminal terminal);
     event JBSwapTerminalRegistry_SetTerminal(uint256 indexed projectId, IJBTerminal terminal);
 
+    /// @notice The project registry.
+    /// @return The projects contract.
     function PROJECTS() external view returns (IJBProjects);
 
+    /// @notice The permit2 utility used for token approvals.
+    /// @return The permit2 contract.
+    function PERMIT2() external view returns (IPermit2);
+
+    /// @notice The default terminal used when a project has not set a specific terminal.
+    /// @return The default terminal.
     function defaultTerminal() external view returns (IJBTerminal);
+
+    /// @notice Whether the terminal for the given project is locked and cannot be changed.
+    /// @param projectId The ID of the project.
+    /// @return Whether the terminal is locked.
     function hasLockedTerminal(uint256 projectId) external view returns (bool);
+
+    /// @notice The terminal for the given project, or the default terminal if none is set.
+    /// @param projectId The ID of the project.
+    /// @return The terminal for the project.
     function terminalOf(uint256 projectId) external view returns (IJBTerminal);
+
+    /// @notice Whether the given terminal is allowed to be set for projects.
+    /// @param terminal The terminal to check.
+    /// @return Whether the terminal is allowed.
     function isTerminalAllowed(IJBTerminal terminal) external view returns (bool);
 
+    /// @notice Allow a terminal to be used by projects.
+    /// @param terminal The terminal to allow.
     function allowTerminal(IJBTerminal terminal) external;
+
+    /// @notice Disallow a terminal from being used by projects.
+    /// @param terminal The terminal to disallow.
     function disallowTerminal(IJBTerminal terminal) external;
+
+    /// @notice Lock the terminal for a project, preventing it from being changed.
+    /// @param projectId The ID of the project to lock the terminal for.
     function lockTerminalFor(uint256 projectId) external;
+
+    /// @notice Set the default terminal used when a project has not set a specific terminal.
+    /// @param terminal The terminal to set as the default.
     function setDefaultTerminal(IJBTerminal terminal) external;
+
+    /// @notice Set the terminal for a specific project.
+    /// @param projectId The ID of the project to set the terminal for.
+    /// @param terminal The terminal to set.
     function setTerminalFor(uint256 projectId, IJBTerminal terminal) external;
 }


### PR DESCRIPTION
## Summary
- Fix 7 "hook" -> "terminal" copy-paste errors in `JBSwapTerminalRegistry.sol` (NatSpec and comments)
- Complete truncated NatSpec for `getPoolFor` (missing return description)
- Add `PERMIT2()` getter to `IJBSwapTerminalRegistry` interface (was missing from interface but present in impl)
- Add `override` to `currentSurplusOf` in both `JBSwapTerminal` and `JBSwapTerminalRegistry`
- Add full NatSpec (`@notice`, `@param`, `@return`) to all functions in `IJBSwapTerminal` and `IJBSwapTerminalRegistry`

## Test plan
- [ ] Verify compilation succeeds
- [ ] Verify existing tests still pass
- [ ] Review NatSpec accuracy against implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)